### PR TITLE
Enabled `ExistentialAny` setting

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -63,3 +63,10 @@ let package = Package(
         )
     ]
 )
+
+for target in package.targets {
+    target.swiftSettings = (target.swiftSettings ?? []) + [
+        .swiftLanguageMode(.v6),
+        .enableUpcomingFeature("ExistentialAny")
+    ]
+}

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
             name: "PrincipleMacros",
             dependencies: [
                 .product(
-                    name: "Principle",
+                    name: "PrincipleCollections",
                     package: "Principle"
                 ),
                 .product(

--- a/Sources/PrincipleMacros/Builders/Declarations/Common/DeclBuilder.swift
+++ b/Sources/PrincipleMacros/Builders/Declarations/Common/DeclBuilder.swift
@@ -10,7 +10,7 @@ import SwiftSyntax
 
 public protocol DeclBuilder {
 
-    var basicDeclaration: BasicDeclSyntax { get }
+    var basicDeclaration: any BasicDeclSyntax { get }
     var settings: DeclBuilderSettings { get }
 
     func build() throws -> [DeclSyntax]

--- a/Sources/PrincipleMacros/Builders/Declarations/Members/PropertyDeclBuilder.swift
+++ b/Sources/PrincipleMacros/Builders/Declarations/Members/PropertyDeclBuilder.swift
@@ -15,7 +15,7 @@ public protocol PropertyDeclBuilder: MemberDeclBuilder {
 
 extension PropertyDeclBuilder {
 
-    public var basicDeclaration: BasicDeclSyntax {
+    public var basicDeclaration: any BasicDeclSyntax {
         property.declaration
     }
 }

--- a/Sources/PrincipleMacros/Builders/Declarations/Types/ClassDeclBuilder.swift
+++ b/Sources/PrincipleMacros/Builders/Declarations/Types/ClassDeclBuilder.swift
@@ -15,7 +15,7 @@ public protocol ClassDeclBuilder: TypeDeclBuilder {
 
 extension ClassDeclBuilder {
 
-    public var typeDeclaration: TypeDeclSyntax {
+    public var typeDeclaration: any TypeDeclSyntax {
         declaration
     }
 }

--- a/Sources/PrincipleMacros/Builders/Declarations/Types/EnumDeclBuilder.swift
+++ b/Sources/PrincipleMacros/Builders/Declarations/Types/EnumDeclBuilder.swift
@@ -15,7 +15,7 @@ public protocol EnumDeclBuilder: TypeDeclBuilder {
 
 extension EnumDeclBuilder {
 
-    public var typeDeclaration: TypeDeclSyntax {
+    public var typeDeclaration: any TypeDeclSyntax {
         declaration
     }
 }

--- a/Sources/PrincipleMacros/Builders/Declarations/Types/StatefulDeclBuilder.swift
+++ b/Sources/PrincipleMacros/Builders/Declarations/Types/StatefulDeclBuilder.swift
@@ -10,12 +10,12 @@ import SwiftSyntax
 
 public protocol StatefulDeclBuilder: TypeDeclBuilder {
 
-    var declaration: StatefulDeclSyntax { get }
+    var declaration: any StatefulDeclSyntax { get }
 }
 
 extension StatefulDeclBuilder {
 
-    public var typeDeclaration: TypeDeclSyntax {
+    public var typeDeclaration: any TypeDeclSyntax {
         declaration
     }
 }

--- a/Sources/PrincipleMacros/Builders/Declarations/Types/StructDeclBuilder.swift
+++ b/Sources/PrincipleMacros/Builders/Declarations/Types/StructDeclBuilder.swift
@@ -15,7 +15,7 @@ public protocol StructDeclBuilder: TypeDeclBuilder {
 
 extension StructDeclBuilder {
 
-    public var typeDeclaration: TypeDeclSyntax {
+    public var typeDeclaration: any TypeDeclSyntax {
         declaration
     }
 }

--- a/Sources/PrincipleMacros/Builders/Declarations/Types/TypeDeclBuilder.swift
+++ b/Sources/PrincipleMacros/Builders/Declarations/Types/TypeDeclBuilder.swift
@@ -10,12 +10,12 @@ import SwiftSyntax
 
 public protocol TypeDeclBuilder: DeclBuilder {
 
-    var typeDeclaration: TypeDeclSyntax { get }
+    var typeDeclaration: any TypeDeclSyntax { get }
 }
 
 extension TypeDeclBuilder {
 
-    public var basicDeclaration: BasicDeclSyntax {
+    public var basicDeclaration: any BasicDeclSyntax {
         typeDeclaration
     }
 }

--- a/Sources/PrincipleMacros/Parsers/Common/Parser.swift
+++ b/Sources/PrincipleMacros/Parsers/Common/Parser.swift
@@ -14,12 +14,12 @@ public protocol Parser {
     associatedtype ResultsCollection: ParserResultsCollection
 
     static func parse(
-        declaration: DeclSyntaxProtocol,
-        in context: MacroExpansionContext
+        declaration: any DeclSyntaxProtocol,
+        in context: any MacroExpansionContext
     ) -> ResultsCollection
 
     static func parse(
         memberBlock: MemberBlockSyntax,
-        in context: MacroExpansionContext
+        in context: any MacroExpansionContext
     ) -> ResultsCollection
 }

--- a/Sources/PrincipleMacros/Parsers/Common/_Parser.swift
+++ b/Sources/PrincipleMacros/Parsers/Common/_Parser.swift
@@ -16,7 +16,7 @@ extension _Parser {
 
     public static func parse(
         memberBlock: MemberBlockSyntax,
-        in context: MacroExpansionContext
+        in context: any MacroExpansionContext
     ) -> ResultsCollection {
         ResultsCollection(
             memberBlock.members.flatMap { member in

--- a/Sources/PrincipleMacros/Parsers/EnumCases/EnumCasesParser.swift
+++ b/Sources/PrincipleMacros/Parsers/EnumCases/EnumCasesParser.swift
@@ -12,8 +12,8 @@ import SwiftSyntaxMacros
 public enum EnumCasesParser: _Parser {
 
     public static func parse(
-        declaration: DeclSyntaxProtocol,
-        in _: MacroExpansionContext
+        declaration: any DeclSyntaxProtocol,
+        in _: any MacroExpansionContext
     ) -> EnumCasesList {
         guard let declaration = EnumCaseDeclSyntax(declaration) else {
             return .init()

--- a/Sources/PrincipleMacros/Parsers/Properties/PropertiesList.swift
+++ b/Sources/PrincipleMacros/Parsers/Properties/PropertiesList.swift
@@ -7,7 +7,7 @@
 //
 
 import Algorithms
-import Principle
+import PrincipleCollections
 import SwiftSyntax
 
 public struct PropertiesList: _ParserResultsCollection {

--- a/Sources/PrincipleMacros/Parsers/Properties/PropertiesParser.swift
+++ b/Sources/PrincipleMacros/Parsers/Properties/PropertiesParser.swift
@@ -12,8 +12,8 @@ import SwiftSyntaxMacros
 public enum PropertiesParser: _Parser {
 
     public static func parse(
-        declaration: DeclSyntaxProtocol,
-        in context: MacroExpansionContext
+        declaration: any DeclSyntaxProtocol,
+        in context: any MacroExpansionContext
     ) -> PropertiesList {
         guard let declaration = VariableDeclSyntax(declaration) else {
             return .init()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- All targets now compile with Swift language mode version 6 and enable the upcoming "ExistentialAny" feature.

- **Refactor**
	- Updated various protocol and property types to use Swift's explicit existential `any` keyword for improved type abstraction and flexibility.
	- Adjusted package dependencies to use a different module.

- **Style**
	- Modernized method and property signatures to align with newer Swift syntax conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->