### PR TITLE
Bump SwiftSyntax to support Swift 6.0-6.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "99431853c87a6b5650f35f74288f2d84c2781ee280b91e34ae7d502413704b4b",
+  "originHash" : "3c38b8418312073f7476856a30a2823c4cfc8c9e3547071f4f7c7a1e555590cb",
   "pins" : [
     {
       "identity" : "principle",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/NSFatalError/Principle",
       "state" : {
-        "revision" : "3db0c92aa564f3b6451063a3374e6ad177cdfebf",
-        "version" : "1.0.0"
+        "revision" : "b7b16cbd21972a675a3543bae2f37aa323dd786b",
+        "version" : "1.0.3"
       }
     },
     {
@@ -31,10 +31,10 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/swiftlang/swift-syntax",
-            from: "600.0.0-latest"
+            "600.0.0" ..< "602.0.0"
         ),
         .package(
             url: "https://github.com/apple/swift-algorithms",

--- a/Sources/PrincipleMacros/Syntax/Extensions/TypeSyntax.swift
+++ b/Sources/PrincipleMacros/Syntax/Extensions/TypeSyntax.swift
@@ -115,23 +115,23 @@ extension GenericArgumentClauseSyntax {
             arguments: GenericArgumentListSyntax(
                 arguments.map { element in
                     #if canImport(SwiftSyntax601)
-                    switch element.argument {
-                    case .type(let type):
-                        GenericArgumentSyntax(
-                            argument: .type(type.standardized),
-                            trailingComma: element.trailingComma?.trimmed.withTrailingSpace
-                        )
-                    default:
-                        GenericArgumentSyntax(
-                            argument: element.argument,
-                            trailingComma: element.trailingComma?.trimmed.withTrailingSpace
-                        )
-                    }
+                        switch element.argument {
+                        case let .type(type):
+                            GenericArgumentSyntax(
+                                argument: .type(type.standardized),
+                                trailingComma: element.trailingComma?.trimmed.withTrailingSpace
+                            )
+                        default:
+                            GenericArgumentSyntax(
+                                argument: element.argument,
+                                trailingComma: element.trailingComma?.trimmed.withTrailingSpace
+                            )
+                        }
                     #else
-                    GenericArgumentSyntax(
-                        argument: element.argument.standardized,
-                        trailingComma: element.trailingComma?.trimmed.withTrailingSpace
-                    )
+                        GenericArgumentSyntax(
+                            argument: element.argument.standardized,
+                            trailingComma: element.trailingComma?.trimmed.withTrailingSpace
+                        )
                     #endif
                 }
             )

--- a/Sources/PrincipleMacros/Syntax/Extensions/TypeSyntax.swift
+++ b/Sources/PrincipleMacros/Syntax/Extensions/TypeSyntax.swift
@@ -114,10 +114,25 @@ extension GenericArgumentClauseSyntax {
         GenericArgumentClauseSyntax(
             arguments: GenericArgumentListSyntax(
                 arguments.map { element in
+                    #if canImport(SwiftSyntax601)
+                    switch element.argument {
+                    case .type(let type):
+                        GenericArgumentSyntax(
+                            argument: .type(type.standardized),
+                            trailingComma: element.trailingComma?.trimmed.withTrailingSpace
+                        )
+                    default:
+                        GenericArgumentSyntax(
+                            argument: element.argument,
+                            trailingComma: element.trailingComma?.trimmed.withTrailingSpace
+                        )
+                    }
+                    #else
                     GenericArgumentSyntax(
                         argument: element.argument.standardized,
                         trailingComma: element.trailingComma?.trimmed.withTrailingSpace
                     )
+                    #endif
                 }
             )
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependency versions and repository URLs for improved compatibility.
  - Adjusted version range for the swift-syntax package to allow for more controlled updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->