### PR TITLE
Removed dependencies other than `SwiftSyntax`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,33 +1,6 @@
 {
-  "originHash" : "3c38b8418312073f7476856a30a2823c4cfc8c9e3547071f4f7c7a1e555590cb",
+  "originHash" : "300b63bc52fc36d4e0a555a932e9715417628f92b25454b2233d22a4d5c6a0f1",
   "pins" : [
-    {
-      "identity" : "principle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/NSFatalError/Principle",
-      "state" : {
-        "revision" : "b7b16cbd21972a675a3543bae2f37aa323dd786b",
-        "version" : "1.0.3"
-      }
-    },
-    {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms",
-      "state" : {
-        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
-        "version" : "1.2.1"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics.git",
-      "state" : {
-        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
-        "version" : "1.0.3"
-      }
-    },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -21,30 +21,14 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/NSFatalError/Principle",
-            from: "1.0.0"
-        ),
-        .package(
             url: "https://github.com/swiftlang/swift-syntax",
             "600.0.0" ..< "602.0.0"
-        ),
-        .package(
-            url: "https://github.com/apple/swift-algorithms",
-            from: "1.2.0"
         )
     ],
     targets: [
         .target(
             name: "PrincipleMacros",
             dependencies: [
-                .product(
-                    name: "PrincipleCollections",
-                    package: "Principle"
-                ),
-                .product(
-                    name: "Algorithms",
-                    package: "swift-algorithms"
-                ),
                 .product(
                     name: "SwiftSyntaxMacros",
                     package: "swift-syntax"

--- a/Sources/PrincipleMacros/Parsers/Properties/PropertiesList.swift
+++ b/Sources/PrincipleMacros/Parsers/Properties/PropertiesList.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2025 Kamil Strzelecki. All rights reserved.
 //
 
-import Algorithms
-import PrincipleCollections
 import SwiftSyntax
 
 public struct PropertiesList: _ParserResultsCollection {
@@ -47,12 +45,6 @@ extension PropertiesList {
 }
 
 extension PropertiesList {
-
-    public var uniqueInferredTypes: [TypeSyntax] {
-        all.lazy.map(\.inferredType)
-            .uniqued(on: \.description)
-            .sorted(on: \.description)
-    }
 
     public func withInferredType(like someType: TypeSyntax) -> Self {
         .init(filter { $0.inferredType.isLike(someType) })


### PR DESCRIPTION
This resolved issues with Xcode projects like:

> External macro implementation type 'ProbingMacros.ProbeMacro' could not be found for macro 'probe(_:preprocessorFlag:)'; '/Users/Kamil/Developer/DerivedData/ProbingPlayground-dfkpmhxillpqacczoccwoezzkapn/Build/Products/Debug/ProbingMacros' produced malformed response

Integration via SPM, even when working in Xcode, is working with and without this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed several package dependencies, streamlining the project’s external requirements.
- **Refactor**
	- Removed the public computed property for retrieving unique inferred types from property lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->